### PR TITLE
Use Correct Search Client

### DIFF
--- a/assets/js/nearby.js
+++ b/assets/js/nearby.js
@@ -8,7 +8,7 @@ const queryLng = urlParams.get('lng');
 const status = document.querySelector("#status");
 const SIGNBASEURL = document.getElementById('sign-base-url').value;
 
-const searchClient = instantMeiliSearch (
+const {searchClient} = instantMeiliSearch (
     document.getElementById('search-url').value,
     document.getElementById('search-api-key').value,
     {


### PR DESCRIPTION
Updated instantMeiliSearch returns more data than just the search client.  Ensure that only the searchClient is passed to instant search.