### PR TITLE
Adding CRC32 Checksum

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -152,7 +152,7 @@ jobs:
       - name: Create Bot Index
         run: bb export-bot-database
       - name: Upload Bot Index To Cloudflare
-        run: aws s3 cp bot.db s3://bot/bot.db
+        run: aws s3 cp bot.db s3://bot/bot.db --checksum-algorithm CRC32
         continue-on-error: true
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_USER }}

--- a/.github/workflows/manual.yaml
+++ b/.github/workflows/manual.yaml
@@ -96,7 +96,7 @@ jobs:
         run: bb export-bot-database
       - name: Upload Bot Index To Cloudflare
         continue-on-error: true
-        run: aws s3 cp bot.db s3://bot/bot.db
+        run: aws s3 cp bot.db s3://bot/bot.db --checksum-algorithm CRC32
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_USER }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_SECRET }}


### PR DESCRIPTION
Recent aws cli updates changed the default checksum for S3 uploads.  Cloudflare still only supports CRC32
