### PR TITLE
feat: move random alias to webserver

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -24,6 +24,7 @@ assets/jsconfig.json
 netlify/
 layouts/
 data/
+!redirect_routes
 config/
 assets/
 archetypes/

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ assets/css/index.css
 bot.db
 
 cypress/screenshots/
+redirect_routes

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,26 @@
+{
+    auto_https off
+    debug
+}
+
+#http://roadsign.pictures/ {
+:80 {
+    route {
+        # Match signindex paths and create regex captures
+        @is_signindex path_regexp signindex ^(/signindex/[0-9]+)(.*)$
+        
+        # Only process signindex paths
+        route @is_signindex {
+            # Import map (uses {http.regexp.signindex.1} as source)
+            import redirect_routes
+            
+            # Rewrite if we have a mapping
+            @has_mapping expression {new-path} != ""
+            rewrite @has_mapping {new-path}{http.regexp.signindex.2}
+        }
+    }
+
+    root * /usr/share/caddy
+    file_server
+
+}

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,9 +1,7 @@
 {
     auto_https off
-    debug
 }
 
-#http://roadsign.pictures/ {
 :80 {
     route {
         # Match signindex paths and create regex captures

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
-FROM pierrezemb/gostatic
+FROM caddy:2.11.4
 
-COPY ./public/ /srv/http/
+COPY ./public/ /usr/share/caddy
+COPY ./Caddyfile /etc/caddy/Caddyfile
+COPY ./redirect_routes /etc/caddy/redirect_routes

--- a/main.go
+++ b/main.go
@@ -85,6 +85,11 @@ func main() {
 		panic(err)
 	}
 
+	err = generator.SaveLookup(appFs, cfg.HugoPath, signLookup.GetRedirects())
+	if err != nil {
+		panic(err)
+	}
+
 	for v := range signConverter.Convert() {
 		err = generator.SaveItem(appFs, cfg.HugoPath, v)
 		if err != nil {

--- a/pkg/converter/sign.go
+++ b/pkg/converter/sign.go
@@ -1,6 +1,8 @@
 package converter
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -8,6 +10,7 @@ import (
 	"highway-sign-portal-builder/pkg/dto"
 	"highway-sign-portal-builder/pkg/generator"
 	"iter"
+	"text/template"
 
 	pluscode "github.com/google/open-location-code/go"
 	"github.com/mmcloughlin/geohash"
@@ -27,7 +30,7 @@ func NewHighwaySignConverter(ctx context.Context, db db.Querier) (Converter, err
 
 func (s SignConverter) Convert() iter.Seq[generator.Generator] {
 	return func(yield func(generator.Generator) bool) {
-		for idx, sign := range *s.signs {
+		for _, sign := range *s.signs {
 			gh := geohash.EncodeWithPrecision(sign.Point.Y(), sign.Point.X(), 5)
 
 			pc := pluscode.Encode(sign.Point.Y(), sign.Point.X(), 10)
@@ -61,8 +64,6 @@ func (s SignConverter) Convert() iter.Seq[generator.Generator] {
 				HasProcessed:         sign.HasProcessed.Bool,
 				Output:               []string{"html", "json"},
 			}
-			aliases := []string{fmt.Sprintf("/signindex/%v", idx)}
-			highwaySignDto.Aliases = aliases
 
 			if sign.LqipHash.Valid {
 				highwaySignDto.LQIP = &sign.LqipHash.String
@@ -84,6 +85,11 @@ func (s SignConverter) Convert() iter.Seq[generator.Generator] {
 		}
 	}
 
+}
+func (s SignConverter) GetRedirects() generator.Lookup {
+	return &caddySignMap{
+		s.signs,
+	}
 }
 
 func (s SignConverter) GetHighQualityLookup() generator.Lookup {
@@ -341,4 +347,46 @@ type geoJsonFeature struct {
 		ImageId string `json:"imageid"`
 		Title   string `json:"title"`
 	} `json:"properties"`
+}
+
+type caddySignMap struct {
+	signs *[]db.SignVwhugohighwaysign
+}
+
+type templateRedirectData struct {
+	OldPath string
+	NewPath string
+}
+
+func (h caddySignMap) GetLookup() ([]byte, error) {
+	hs := *h.signs
+
+	//Get template
+	tmpl := template.Must(template.ParseFiles("redirect_template.text"))
+	var redirects []templateRedirectData
+	for i, v := range hs {
+		oldPath := fmt.Sprintf("/signindex/%v", i)
+		newPath := fmt.Sprintf("/sign/%s", v.Imageid.String())
+		redirects = append(redirects, templateRedirectData{
+			OldPath: oldPath,
+			NewPath: newPath,
+		})
+	}
+
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+
+	err := tmpl.Execute(w, redirects)
+	if err != nil {
+		return nil, err
+	}
+	err = w.Flush()
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}
+
+func (h caddySignMap) OutLookupFiles() []string {
+	return []string{"./redirect_routes"}
 }

--- a/pkg/dto/highwaysign.go
+++ b/pkg/dto/highwaysign.go
@@ -42,7 +42,6 @@ type HighwaySignDto struct {
 	HasProcessed         bool     `yaml:"hasProcessed"`
 	Thumbnail            *string  `yaml:"thumbnail,omitempty"`
 	Output               []string `yaml:"outputs,omitempty"`
-	Aliases              []string `yaml:"aliases,omitempty"`
 }
 
 func (s HighwaySignDto) OutFile() string {

--- a/redirect_template.text
+++ b/redirect_template.text
@@ -1,0 +1,6 @@
+map {http.regexp.signindex.1}  {new-path} {
+    {{- range . }}
+    {{.OldPath}}  {{.NewPath}}
+    {{- end }}
+    default ""
+}


### PR DESCRIPTION
- Use Caddyfile for webserver
- Remove Hugo aliases to /signindex for Random Signs
- Added Caddyfile rewrite mapping to handle random signs