### PR TITLE
ci: caddy runs on 80

### DIFF
--- a/fly.production.toml
+++ b/fly.production.toml
@@ -9,7 +9,7 @@ primary_region = "sea"
 [build]
 
 [http_service]
-  internal_port = 8043
+  internal_port = 80
   force_https = true
   auto_stop_machines = true
   auto_start_machines = true


### PR DESCRIPTION
Migrated to Caddy without updating port number.  Correct port number is 80.